### PR TITLE
Add a baseline benchmark

### DIFF
--- a/benchmark/bm_io_pipe.rb
+++ b/benchmark/bm_io_pipe.rb
@@ -38,6 +38,20 @@ class UMBenchmark
     end
   end
 
+  def do_baseline
+    GROUPS.times do
+      r, w = IO.pipe
+      r.sync = true
+      w.sync = true
+      ITERATIONS.times {
+        w.write(DATA)
+        r.read(SIZE)
+      }
+      r.close
+      w.close
+    end
+  end
+
   def do_scheduler(scheduler, ios)
     GROUPS.times do
       r, w = IO.pipe

--- a/benchmark/common.rb
+++ b/benchmark/common.rb
@@ -54,6 +54,7 @@ class UMBenchmark
   end
 
   @@benchmarks = {
+    baseline:     [:baseline,     "No Concurrency"],
     threads:      [:threads,      "Threads"],
     thread_pool:  [:thread_pool,  "ThreadPool"],
     async_uring:  [:scheduler,    "Async uring"],
@@ -67,6 +68,10 @@ class UMBenchmark
     @@benchmarks.each do |sym, (doer, name)|
       b.report(name) { send(:"run_#{sym}") } if respond_to?(:"do_#{doer}")
     end
+  end
+
+  def run_baseline
+    do_baseline
   end
 
   def run_threads


### PR DESCRIPTION
Add a benchmark with no concurrency.  When benchmarking concurrency / parallelism, it is a good idea to add a baseline with no concurrency. That way we can see what kind of speed up our concurrency strategy buys us.

I'm not sure what these benchmarks are trying to show, but none of the Fiber benchmarks seem to buy any speed over simply writing the code with no Fibers or Threads.  I think it would be more useful if the benchmarks had some sort of demonstration that showed a performance improvement over simple linear code.