### PR TITLE
Implement inotify API

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,18 @@
 
 - Fix all futex value (Queue, Mutex) to be aligned
 
+## inotify
+
+API:
+
+```ruby
+MASK = UM::IN_CREATE | UM::IN_DELETE |
+       UM::IN_MODIFY | UM::IN_MOVED_TO
+@machine.file_watch(path, MASK) do |path, evt|
+  do_something_with_evt(path, evt)
+end
+```
+
 ## Buffer rings - automatic management
 
 ```ruby

--- a/ext/um/um_const.c
+++ b/ext/um/um_const.c
@@ -14,6 +14,7 @@
 #include <net/if.h>
 #include <poll.h>
 #include <signal.h>
+#include <sys/inotify.h>
 
 #define DEF_CONST_INT(mod, v) rb_define_const(mod, #v, INT2NUM(v))
 
@@ -437,4 +438,30 @@ void um_define_net_constants(VALUE mod) {
   DEF_CONST_INT(mod, SIGUSR2);
   DEF_CONST_INT(mod, SIGPWR);
   DEF_CONST_INT(mod, SIGPOLL);
+
+  DEF_CONST_INT(mod, IN_ACCESS);
+  DEF_CONST_INT(mod, IN_ATTRIB);
+  DEF_CONST_INT(mod, IN_CLOSE_WRITE);
+  DEF_CONST_INT(mod, IN_CLOSE_NOWRITE);
+  DEF_CONST_INT(mod, IN_CREATE);
+  DEF_CONST_INT(mod, IN_DELETE);
+  DEF_CONST_INT(mod, IN_DELETE_SELF);
+  DEF_CONST_INT(mod, IN_MODIFY);
+  DEF_CONST_INT(mod, IN_MOVE_SELF);
+  DEF_CONST_INT(mod, IN_MOVED_FROM);
+  DEF_CONST_INT(mod, IN_MOVED_TO);
+  DEF_CONST_INT(mod, IN_OPEN);
+  DEF_CONST_INT(mod, IN_ALL_EVENTS);
+  DEF_CONST_INT(mod, IN_MOVE);
+  DEF_CONST_INT(mod, IN_CLOSE);
+  DEF_CONST_INT(mod, IN_DONT_FOLLOW);
+  DEF_CONST_INT(mod, IN_EXCL_UNLINK);
+  DEF_CONST_INT(mod, IN_MASK_ADD);
+  DEF_CONST_INT(mod, IN_ONESHOT);
+  DEF_CONST_INT(mod, IN_ONLYDIR);
+  DEF_CONST_INT(mod, IN_MASK_CREATE);
+  DEF_CONST_INT(mod, IN_IGNORED);
+  DEF_CONST_INT(mod, IN_ISDIR);
+  DEF_CONST_INT(mod, IN_Q_OVERFLOW);
+  DEF_CONST_INT(mod, IN_UNMOUNT);
 }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -85,4 +85,19 @@ class UMBaseTest < Minitest::Test
       @@port += 1
     end
   end
+
+  def make_tmp_file_tree(dir, spec)
+    FileUtils.mkdir(dir) rescue nil
+    spec.each do |k, v|
+      fn = File.join(dir, k.to_s)
+      case v
+      when String
+        IO.write(fn, v)
+      when Hash
+        FileUtils.mkdir(fn) rescue nil
+        make_tmp_file_tree(fn, v)
+      end
+    end
+    dir
+  end
 end


### PR DESCRIPTION
This PR adds low-level methods for interacting with the `inotify` interface for monitoring file system events. It also adds a higher-level `file_watch` method for watching directories.

### Low-level API

```ruby
fd = UM.inotify_init
wd = UM.inotify_add_watch(fd, fn, UM::IN_CREATE | UM::IN_DELETE | UM::IN_CLOSE_WRITE)
events = machine.inotify_get_events(fd)
```

### Watching a directory (and all its subdirectories)

```ruby
# inifinite loop:
machine.file_watch(dir, UM::IN_CREATE | UM::IN_DELETE | UM::IN_CLOSE_WRITE) do |event|
  p mask: event[:mask], fn: event[:fn]
end
```