### PR TITLE
chore: avoid errors stemming from unused-parameter

### DIFF
--- a/ext/um/extconf.rb
+++ b/ext/um/extconf.rb
@@ -74,7 +74,11 @@ $defs << '-DHAVE_IO_URING_PREP_BIND'            if config[:prep_bind]
 $defs << '-DHAVE_IO_URING_PREP_LISTEN'          if config[:prep_listen]
 $defs << '-DHAVE_IO_URING_SEND_VECTORIZED'      if config[:send_vectoized]
 
-$CFLAGS << ' -Werror -Wall -Wextra'
+# NOTE: -Wall -Wextra enable -Wunused-parameter (https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-W)
+# And -Wunused-parameter throws in:
+# - ruby-4.0.0/ruby/internal/gc.h
+# - ext/um/um.c
+$CFLAGS << ' -Wno-unused-parameter -Werror -Wall -Wextra'
 
 if ENV['SANITIZE']
   $CFLAGS << ' -fsanitize=undefined,address -lasan'


### PR DESCRIPTION
Hey, we talked briefly on wroc_love.rb today :)

I still don't understand why it's happening on my nixOS setup but doesn't trigger in CI nor on your machine.
But to the best of my understanding this should happen always on current main? Esp. the `um.c` warning on line 360 is obviously correct - all parameters of function `um_profile_switch` are unused since the body is commented out (as of f67ed61).

Relevant log below:
```
/nix/store/3zcs23yc1wbjkmd7s1fp7dncvy17dhr3-gnumake-4.4.1/bin/make
compiling ../../../../ext/um/um.c
In file included from /nix/store/j7w4vyc3m1icw293l43lnj1dczdz5i0n-ruby-4.0.2/include/ruby-4.0.0/ruby/internal/core/rarray.h:32,
                 from /nix/store/j7w4vyc3m1icw293l43lnj1dczdz5i0n-ruby-4.0.2/include/ruby-4.0.0/ruby/internal/core.h:23,
                 from /nix/store/j7w4vyc3m1icw293l43lnj1dczdz5i0n-ruby-4.0.2/include/ruby-4.0.0/ruby/ruby.h:29,
                 from /nix/store/j7w4vyc3m1icw293l43lnj1dczdz5i0n-ruby-4.0.2/include/ruby-4.0.0/ruby.h:38,
                 from ../../../../ext/um/um.h:4,
                 from ../../../../ext/um/um.c:1:
/nix/store/j7w4vyc3m1icw293l43lnj1dczdz5i0n-ruby-4.0.2/include/ruby-4.0.0/ruby/internal/gc.h: In function ‘rb_gc_force_recycle’:
/nix/store/j7w4vyc3m1icw293l43lnj1dczdz5i0n-ruby-4.0.2/include/ruby-4.0.0/ruby/internal/gc.h:827:46: error: unused parameter ‘obj’ [-Werror=unused-parameter]
  827 | static inline void rb_gc_force_recycle(VALUE obj){}
      |                                        ~~~~~~^~~
../../../../ext/um/um.c: In function ‘um_profile_wait_cqe_pre’:
../../../../ext/um/um.c:285:48: error: unused parameter ‘machine’ [-Werror=unused-parameter]
  285 | inline void um_profile_wait_cqe_pre(struct um *machine, double *time_monotonic0, VALUE *fiber) {
      |                                     ~~~~~~~~~~~^~~~~~~
../../../../ext/um/um.c:285:89: error: unused parameter ‘fiber’ [-Werror=unused-parameter]
  285 | inline void um_profile_wait_cqe_pre(struct um *machine, double *time_monotonic0, VALUE *fiber) {
      |                                                                                  ~~~~~~~^~~~~
../../../../ext/um/um.c: In function ‘um_profile_wait_cqe_post’:
../../../../ext/um/um.c:294:88: error: unused parameter ‘fiber’ [-Werror=unused-parameter]
  294 | inline void um_profile_wait_cqe_post(struct um *machine, double time_monotonic0, VALUE fiber) {
      |                                                                                  ~~~~~~^~~~~
../../../../ext/um/um.c: In function ‘um_profile_switch’:
../../../../ext/um/um.c:360:42: error: unused parameter ‘machine’ [-Werror=unused-parameter]
  360 | inline void um_profile_switch(struct um *machine, VALUE next_fiber) {
      |                               ~~~~~~~~~~~^~~~~~~
../../../../ext/um/um.c:360:57: error: unused parameter ‘next_fiber’ [-Werror=unused-parameter]
  360 | inline void um_profile_switch(struct um *machine, VALUE next_fiber) {
      |                                                   ~~~~~~^~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:251: um.o] Error 1
```